### PR TITLE
use splitseq instead of split

### DIFF
--- a/datastar/signals.go
+++ b/datastar/signals.go
@@ -62,8 +62,8 @@ func (sse *ServerSentEventGenerator) PatchSignals(signalsContents []byte, opts .
 	if options.OnlyIfMissing {
 		dataRows = append(dataRows, OnlyIfMissingDatalineLiteral+strconv.FormatBool(options.OnlyIfMissing))
 	}
-	lines := bytes.Split(signalsContents, newLineBuf)
-	for _, line := range lines {
+	lines := bytes.SplitSeq(signalsContents, newLineBuf)
+	for line := range lines {
 		dataRows = append(dataRows, SignalsDatalineLiteral+string(line))
 	}
 


### PR DESCRIPTION
Tiny one. Saw a suggestion from gopls that `Ranging over SplitSeq is more efficient` for bytes. Probably miniscule differences but why not.