### PR TITLE
Change default compression strategy to `ServerPriority`

### DIFF
--- a/datastar/sse-compression.go
+++ b/datastar/sse-compression.go
@@ -234,7 +234,7 @@ func WithForced() CompressionOption {
 func WithCompression(opts ...CompressionOption) SSEOption {
 	return func(sse *ServerSentEventGenerator) {
 		cfg := &compressionOptions{
-			CompressionStrategy: ClientPriority,
+			CompressionStrategy: ServerPriority,
 			ClientEncodings:     parseEncodings(sse.acceptEncoding),
 		}
 

--- a/datastar/sse-compression.go
+++ b/datastar/sse-compression.go
@@ -252,9 +252,9 @@ func WithCompression(opts ...CompressionOption) SSEOption {
 		}
 
 		switch cfg.CompressionStrategy {
-		case ClientPriority:
-			for _, clientEnc := range cfg.ClientEncodings {
-				for _, comp := range cfg.Compressors {
+		case ServerPriority:
+			for _, comp := range cfg.Compressors {
+				for _, clientEnc := range cfg.ClientEncodings {
 					if comp.Encoding == clientEnc {
 						sse.w = comp.Compressor.Get(sse.w)
 						sse.encoding = comp.Encoding
@@ -262,9 +262,9 @@ func WithCompression(opts ...CompressionOption) SSEOption {
 					}
 				}
 			}
-		case ServerPriority:
-			for _, comp := range cfg.Compressors {
-				for _, clientEnc := range cfg.ClientEncodings {
+		case ClientPriority:
+			for _, clientEnc := range cfg.ClientEncodings {
+				for _, comp := range cfg.Compressors {
 					if comp.Encoding == clientEnc {
 						sse.w = comp.Compressor.Get(sse.w)
 						sse.encoding = comp.Encoding


### PR DESCRIPTION
Changes the default compression strategy to `ServerPriority`, which uses good defaults. Browsers generally send `Accept-Encoding: gzip, deflate, br, zstd`, which is ordered by compatibility, rather than efficiency, which means that gzip will be used, even if brotli and zstd are supported.